### PR TITLE
fix ReferenceError in getAWSProfiles function

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -72,7 +72,7 @@ function getAWSProfiles(pathOverride) {
         .then(credentials =>
             credentials && typeof credentials === "object" ? Object.keys(credentials) : []
         )
-        .catch(err => {
+        .catch(error => {
             throw new VError(error, "Failed getting profiles");
         });
 }


### PR DESCRIPTION
ReferenceError: error is not defined
 at .../node_modules/aws-get-credentials/source/index.js:76:30